### PR TITLE
Add the mandatory appId field

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ app.listen(port,
 function configToManifest(config)
 {
     return {
+        appId: config.name,
         name: config.name,
         version: "1",
         title: config.title,


### PR DESCRIPTION
appId is mandatory in the [FDC3 AppDirectory specification](https://fdc3.finos.org/1.0/appd-spec#tag/Application/paths/~1v1~1apps~1{appId}/get).

Set the field accordingly.